### PR TITLE
Add dummy values for lastRestartDate in dev

### DIFF
--- a/roles/aks-apply/files/dev/digitransit-deployer-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-deployer-dev.yml
@@ -71,6 +71,7 @@ spec:
     metadata:
       labels:
         app: digitransit-deployer
+        lastRestartDate: dummy-value
     spec:
       serviceAccountName: digitransit-deployer
       affinity:

--- a/roles/aks-apply/files/dev/digitransit-performance-tests-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-performance-tests-dev.yml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: digitransit-performance-tests
+        lastRestartDate: dummy-value
     spec:
       affinity:
         podAntiAffinity:

--- a/roles/aks-apply/files/dev/digitransit-proxy-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-proxy-dev.yml
@@ -40,6 +40,7 @@ spec:
     metadata:
       labels:
         app: digitransit-proxy
+        lastRestartDate: dummy-value
     spec:
       priorityClassName: high-priority
       containers:

--- a/roles/aks-apply/files/dev/digitransit-sentry-analytics-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-sentry-analytics-dev.yml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: digitransit-sentry-analytics
+        lastRestartDate: dummy-value
     spec:
       containers:
       - name: digitransit-sentry-analytics

--- a/roles/aks-apply/files/dev/digitransit-site-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-site-dev.yml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: digitransit-site
+        lastRestartDate: dummy-value
     spec:
       affinity:
         podAntiAffinity:

--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-dev.yml
@@ -34,6 +34,7 @@ spec:
     metadata:
       labels:
         app: digitransit-ui-hsl
+        lastRestartDate: dummy-value
     spec:
       priorityClassName: medium-priority
       affinity:

--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-next-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-next-dev.yml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: digitransit-ui-hsl-next
+        lastRestartDate: dummy-value
     spec:
       priorityClassName: medium-priority
       affinity:

--- a/roles/aks-apply/files/dev/digitransit-ui-matka-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-matka-dev.yml
@@ -46,6 +46,7 @@ spec:
     metadata:
       labels:
         app: digitransit-ui-matka
+        lastRestartDate: dummy-value
     spec:
       priorityClassName: medium-priority
       affinity:

--- a/roles/aks-apply/files/dev/digitransit-ui-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-waltti-dev.yml
@@ -34,6 +34,7 @@ spec:
     metadata:
       labels:
         app: digitransit-ui-waltti
+        lastRestartDate: dummy-value
     spec:
       priorityClassName: medium-priority
       affinity:

--- a/roles/aks-apply/files/dev/graphiql-dev.yml
+++ b/roles/aks-apply/files/dev/graphiql-dev.yml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: graphiql
+        lastRestartDate: dummy-value
     spec:
       affinity:
         podAntiAffinity:

--- a/roles/aks-apply/files/dev/hsl-map-server-dev.yml
+++ b/roles/aks-apply/files/dev/hsl-map-server-dev.yml
@@ -34,7 +34,8 @@ spec:
   template:
     metadata:
       labels:
-        app: hsl-map-server  
+        app: hsl-map-server
+        lastRestartDate: dummy-value
     spec:
       priorityClassName: medium-priority
       affinity:

--- a/roles/aks-apply/files/dev/hsl-timetable-container-dev.yml
+++ b/roles/aks-apply/files/dev/hsl-timetable-container-dev.yml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: hsl-timetable-container
+        lastRestartDate: dummy-value
     spec:
       affinity:
         podAntiAffinity:

--- a/roles/aks-apply/files/dev/navigator-server-dev.yml
+++ b/roles/aks-apply/files/dev/navigator-server-dev.yml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: navigator-server
+        lastRestartDate: dummy-value
     spec:
       affinity:
         podAntiAffinity:

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-finland-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-finland-dev.yml
@@ -32,6 +32,7 @@ spec:
     metadata:
       labels:
         app: opentripplanner-data-con-finland
+        lastRestartDate: dummy-value
     spec:
       affinity:
         podAntiAffinity:

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-hsl-dev.yml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: opentripplanner-data-con-hsl
+        lastRestartDate: dummy-value
     spec:
       affinity:
         podAntiAffinity:

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-waltti-dev.yml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: opentripplanner-data-con-waltti
+        lastRestartDate: dummy-value
     spec:
       affinity:
         podAntiAffinity:

--- a/roles/aks-apply/files/dev/opentripplanner-finland-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-finland-dev.yml
@@ -36,6 +36,7 @@ spec:
     metadata:
       labels:
         app: opentripplanner-finland
+        lastRestartDate: dummy-value
     spec:
       priorityClassName: medium-priority
       containers:

--- a/roles/aks-apply/files/dev/opentripplanner-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-hsl-dev.yml
@@ -35,6 +35,7 @@ spec:
     metadata:
       labels:
         app: opentripplanner-hsl
+        lastRestartDate: dummy-value
     spec:
       priorityClassName: medium-priority
       containers:

--- a/roles/aks-apply/files/dev/opentripplanner-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-waltti-dev.yml
@@ -36,6 +36,7 @@ spec:
     metadata:
       labels:
         app: opentripplanner-waltti
+        lastRestartDate: dummy-value
     spec:
       priorityClassName: medium-priority
       containers:

--- a/roles/aks-apply/files/dev/pelias-api-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-api-dev.yml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: pelias-api
+        lastRestartDate: dummy-value
     spec:
       priorityClassName: medium-priority
       affinity:

--- a/roles/aks-apply/files/dev/pelias-data-container-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-data-container-dev.yml
@@ -37,6 +37,7 @@ spec:
     metadata:
       labels:
         app: pelias-data-container
+        lastRestartDate: dummy-value
     spec:
       affinity:
         podAntiAffinity:

--- a/roles/aks-apply/files/dev/raildigitraffic2gtfsrt-dev.yml
+++ b/roles/aks-apply/files/dev/raildigitraffic2gtfsrt-dev.yml
@@ -34,7 +34,8 @@ spec:
   template:
     metadata:
       labels:
-        app: raildigitraffic2gtfsrt   
+        app: raildigitraffic2gtfsrt
+        lastRestartDate: dummy-value
     spec:
       affinity:
         podAntiAffinity:

--- a/roles/aks-apply/files/dev/siri2gtfsrt-dev.yml
+++ b/roles/aks-apply/files/dev/siri2gtfsrt-dev.yml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: siri2gtfsrt
+        lastRestartDate: dummy-value
     spec:
       affinity:
         podAntiAffinity:

--- a/roles/aks-apply/files/dev/yleisviestipalvelu-dev.yml
+++ b/roles/aks-apply/files/dev/yleisviestipalvelu-dev.yml
@@ -33,6 +33,7 @@ spec:
     metadata:
       labels:
         app: yleisviestipalvelu
+        lastRestartDate: dummy-value
     spec:
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
These dummy values replace the existing values and instead of using the value from lastRestartDate, deployer checks when the pods were last restarted.