### PR TITLE
Add otp and hsl-timetable-container restart dependencies to UIs

### DIFF
--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-dev.yml
@@ -20,6 +20,8 @@ metadata:
     update: auto
     restartAt: "03.20_13.20"
     restartLimitInterval: "180"
+    restartAfterDeployments: "opentripplanner-hsl_hsl-timetable-container"
+    restartDelay: "5"
 spec:
   selector:
     matchLabels:

--- a/roles/aks-apply/files/dev/digitransit-ui-matka-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-matka-dev.yml
@@ -32,6 +32,8 @@ metadata:
     update: auto
     restartAt: "03.00_13.00"
     restartLimitInterval: "480"
+    restartAfterDeployments: "opentripplanner-finland"
+    restartDelay: "5"
 spec:
   selector:
     matchLabels:

--- a/roles/aks-apply/files/dev/digitransit-ui-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-waltti-dev.yml
@@ -20,6 +20,8 @@ metadata:
     update: auto
     restartAt: "03.10_13.10"
     restartLimitInterval: "480"
+    restartAfterDeployments: "opentripplanner-waltti"
+    restartDelay: "5"
 spec:
   selector:
     matchLabels:

--- a/roles/aks-apply/files/prod/digitransit-ui-hsl-prod.yml
+++ b/roles/aks-apply/files/prod/digitransit-ui-hsl-prod.yml
@@ -20,6 +20,8 @@ metadata:
     update: auto
     restartAt: "03.20_13.20"
     restartLimitInterval: "180"
+    restartAfterDeployments: "opentripplanner-hsl_hsl-timetable-container"
+    restartDelay: "5"
 spec:
   selector:
     matchLabels:

--- a/roles/aks-apply/files/prod/digitransit-ui-matka-prod.yml
+++ b/roles/aks-apply/files/prod/digitransit-ui-matka-prod.yml
@@ -32,6 +32,8 @@ metadata:
     update: auto
     restartAt: "03.00_13.00"
     restartLimitInterval: "480"
+    restartAfterDeployments: "opentripplanner-finland"
+    restartDelay: "5"
 spec:
   selector:
     matchLabels:

--- a/roles/aks-apply/files/prod/digitransit-ui-waltti-prod.yml
+++ b/roles/aks-apply/files/prod/digitransit-ui-waltti-prod.yml
@@ -20,6 +20,8 @@ metadata:
     update: auto
     restartAt: "03.10_13.10"
     restartLimitInterval: "480"
+    restartAfterDeployments: "opentripplanner-waltti"
+    restartDelay: "5"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
* UI fetches information from OTP and hsl-timetable-container (in HSL case) at start, therefore UI should restart once those dependencies have restarted