### PR TITLE
Update prod hsl-map-server cpu alloc to match thread usage

### DIFF
--- a/roles/aks-apply/files/prod/hsl-map-server-prod.yml
+++ b/roles/aks-apply/files/prod/hsl-map-server-prod.yml
@@ -22,7 +22,7 @@ metadata:
     restartAfterDeployments: "opentripplanner-hsl_opentripplanner-waltti" #TODO include finland when we figure out best way to circumvent label length restriction _opentripplanner-finland
     restartDelay: "5"
 spec:
-  replicas: 8
+  replicas: 4
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -87,7 +87,7 @@ spec:
         resources:
           requests:
             memory: 4096Mi
-            cpu: 1500m
+            cpu: 4000m
           limits:
             memory: 4096Mi
-            cpu: 4000m
+            cpu: 7900m


### PR DESCRIPTION
* hsl-map-server uses 8 threads so therefore it makes sense to max the cpu usage to "8" cores instead of "4"
  - This should roughly double the throughput therefore number of instances can be reduced. However, this should be monitored a bit because cpu might not be throttling throughput.