### PR TITLE
WIP: Refactor probes

### DIFF
--- a/roles/aks-apply/files/dev/digitransit-proxy-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-proxy-dev.yml
@@ -49,6 +49,13 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
+          httpGet:
+            port: 8080
+            path: /
         readinessProbe:
           periodSeconds: 10
           timeoutSeconds: 10
@@ -57,7 +64,6 @@ spec:
             port: 8080
             path: /
         livenessProbe:
-          initialDelaySeconds: 150
           periodSeconds: 30
           timeoutSeconds: 10
           failureThreshold: 2

--- a/roles/aks-apply/files/dev/digitransit-site-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-site-dev.yml
@@ -53,6 +53,13 @@ spec:
           allowPrivilegeEscalation: false
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
+          httpGet:
+            port: 8080
+            path: "/"
         readinessProbe:
           periodSeconds: 5
           timeoutSeconds: 10
@@ -61,7 +68,6 @@ spec:
             port: 8080
             path: "/"
         livenessProbe:
-          initialDelaySeconds: 150
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 5

--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-dev.yml
@@ -55,6 +55,13 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
+        startupProbe:
+          httpGet:
+            path: /
+            port: 8080
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
         readinessProbe:
           httpGet:
             path: /
@@ -66,7 +73,6 @@ spec:
           httpGet:
             path: /
             port: 8080
-          initialDelaySeconds: 150
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 10

--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-next-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-next-dev.yml
@@ -52,6 +52,13 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
+        startupProbe:
+          httpGet:
+            path: /
+            port: 8080
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
         readinessProbe:
           httpGet:
             path: /
@@ -63,7 +70,6 @@ spec:
           httpGet:
             path: /
             port: 8080
-          initialDelaySeconds: 150
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 10

--- a/roles/aks-apply/files/dev/digitransit-ui-matka-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-matka-dev.yml
@@ -67,6 +67,13 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
+        startupProbe:
+          httpGet:
+            path: /
+            port: 8080
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
         readinessProbe:
           httpGet:
             path: /
@@ -78,7 +85,6 @@ spec:
           httpGet:
             path: /
             port: 8080
-          initialDelaySeconds: 150
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 10

--- a/roles/aks-apply/files/dev/digitransit-ui-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-waltti-dev.yml
@@ -55,6 +55,13 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
+        startupProbe:
+          httpGet:
+            path: /
+            port: 8080
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
         readinessProbe:
           httpGet:
             path: /
@@ -66,7 +73,6 @@ spec:
           httpGet:
             path: /
             port: 8080
-          initialDelaySeconds: 150
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 10

--- a/roles/aks-apply/files/dev/graphiql-dev.yml
+++ b/roles/aks-apply/files/dev/graphiql-dev.yml
@@ -53,6 +53,13 @@ spec:
           allowPrivilegeEscalation: false
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 12
+          httpGet:
+            port: 8080
+            path: "/graphiql/hsl"
         readinessProbe:
           periodSeconds: 10
           timeoutSeconds: 10
@@ -61,7 +68,6 @@ spec:
             port: 8080
             path: "/graphiql/hsl"
         livenessProbe:
-          initialDelaySeconds: 60
           periodSeconds: 60
           timeoutSeconds: 10
           failureThreshold: 2

--- a/roles/aks-apply/files/dev/hsl-map-server-dev.yml
+++ b/roles/aks-apply/files/dev/hsl-map-server-dev.yml
@@ -56,6 +56,13 @@ spec:
           allowPrivilegeEscalation: false
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
+          httpGet:
+            port: 8080
+            path: /map/v1/hsl-map/index.json
         readinessProbe:
           periodSeconds: 5
           timeoutSeconds: 10
@@ -64,7 +71,6 @@ spec:
             port: 8080
             path: /map/v1/hsl-map/index.json
         livenessProbe:
-          initialDelaySeconds: 150
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 10

--- a/roles/aks-apply/files/dev/hsl-timetable-container-dev.yml
+++ b/roles/aks-apply/files/dev/hsl-timetable-container-dev.yml
@@ -53,6 +53,13 @@ spec:
           allowPrivilegeEscalation: false
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
+          httpGet:
+            port: 8080
+            path: "/version.txt"
         readinessProbe:
           periodSeconds: 5
           timeoutSeconds: 10
@@ -61,7 +68,6 @@ spec:
             port: 8080
             path: "/version.txt"
         livenessProbe:
-          initialDelaySeconds: 150
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 5

--- a/roles/aks-apply/files/dev/navigator-server-dev.yml
+++ b/roles/aks-apply/files/dev/navigator-server-dev.yml
@@ -53,6 +53,13 @@ spec:
           allowPrivilegeEscalation: false
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
+          httpGet:
+            port: 8080
+            path: /
         readinessProbe:
           periodSeconds: 5
           timeoutSeconds: 10
@@ -61,7 +68,6 @@ spec:
             port: 8080
             path: /
         livenessProbe:
-          initialDelaySeconds: 150
           periodSeconds: 10
           failureThreshold: 5
           timeoutSeconds: 10

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-finland-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-finland-dev.yml
@@ -52,6 +52,13 @@ spec:
           allowPrivilegeEscalation: false
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
+          httpGet:
+            port: 8080
+            path: "/version.txt"
         readinessProbe:
           periodSeconds: 5
           timeoutSeconds: 10
@@ -60,7 +67,6 @@ spec:
             port: 8080
             path: "/version.txt"
         livenessProbe:
-          initialDelaySeconds: 150
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 5

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-hsl-dev.yml
@@ -53,6 +53,13 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
+          httpGet:
+            port: 8080
+            path: "/version.txt"
         readinessProbe:
           periodSeconds: 5
           timeoutSeconds: 10
@@ -61,7 +68,6 @@ spec:
             port: 8080
             path: "/version.txt"
         livenessProbe:
-          initialDelaySeconds: 150
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 5

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-waltti-dev.yml
@@ -53,6 +53,13 @@ spec:
           allowPrivilegeEscalation: false
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 100
+          httpGet:
+            port: 8080
+            path: "/version.txt"
         readinessProbe:
           periodSeconds: 5
           timeoutSeconds: 10
@@ -61,7 +68,6 @@ spec:
             port: 8080
             path: "/version.txt"
         livenessProbe:
-          initialDelaySeconds: 500
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 2

--- a/roles/aks-apply/files/dev/pelias-api-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-api-dev.yml
@@ -54,6 +54,13 @@ spec:
           allowPrivilegeEscalation: false
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
+          httpGet:
+            port: 8080
+            path: /v1/search?text=helsinki
         readinessProbe:
           periodSeconds: 5
           timeoutSeconds: 10
@@ -62,7 +69,6 @@ spec:
             port: 8080
             path: /v1/search?text=helsinki
         livenessProbe:
-          initialDelaySeconds: 150
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 5

--- a/roles/aks-apply/files/dev/pelias-data-container-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-data-container-dev.yml
@@ -62,6 +62,13 @@ spec:
           name: vip0
         - containerPort: 9300
           name: vip1
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 120
+          httpGet:
+            port: 9200
+            path: /_search?q=name.fi:helsinki
         readinessProbe:
           periodSeconds: 5
           timeoutSeconds: 10
@@ -70,7 +77,6 @@ spec:
             port: 9200
             path: /_search?q=name.fi:helsinki
         livenessProbe:
-          initialDelaySeconds: 600
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3

--- a/roles/aks-apply/files/dev/raildigitraffic2gtfsrt-dev.yml
+++ b/roles/aks-apply/files/dev/raildigitraffic2gtfsrt-dev.yml
@@ -55,6 +55,13 @@ spec:
           allowPrivilegeEscalation: false
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 280
+          httpGet:
+            port: 8080
+            path: "/hsl"
         readinessProbe:
           periodSeconds: 10
           timeoutSeconds: 10
@@ -63,7 +70,6 @@ spec:
             port: 8080
             path: "/hsl"
         livenessProbe:
-          initialDelaySeconds: 1400
           periodSeconds: 30
           timeoutSeconds: 10
           failureThreshold: 5

--- a/roles/aks-apply/files/dev/siri2gtfsrt-dev.yml
+++ b/roles/aks-apply/files/dev/siri2gtfsrt-dev.yml
@@ -53,6 +53,13 @@ spec:
           allowPrivilegeEscalation: false
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
+          httpGet:
+            port: 8080
+            path: /FOLI
         readinessProbe:
           periodSeconds: 5
           timeoutSeconds: 10
@@ -61,7 +68,6 @@ spec:
             port: 8080
             path: /FOLI
         livenessProbe:
-          initialDelaySeconds: 120
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 5

--- a/roles/aks-apply/files/dev/yleisviestipalvelu-dev.yml
+++ b/roles/aks-apply/files/dev/yleisviestipalvelu-dev.yml
@@ -56,6 +56,13 @@ spec:
           allowPrivilegeEscalation: false
         ports:
         - containerPort: 8080
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
+          httpGet:
+            port: 8080
+            path: /
         readinessProbe:
           periodSeconds: 5
           timeoutSeconds: 10
@@ -64,7 +71,6 @@ spec:
             port: 8080
             path: /
         livenessProbe:
-          initialDelaySeconds: 12
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 5


### PR DESCRIPTION
* Uses startupProbe to get rid of need to use initialDelaySeconds in livenessProbe

<b>NOTE this feature is only in alpha in kubernetes 1.16 so perhaps we should enable this later</b>