### PR TITLE
Move some dev data builds to start a bit earlier

### DIFF
--- a/roles/aks-apply/files/dev/otp-data-builder-finland-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-finland-dev-dev.yml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: otp-data-builder-finland-dev
 spec:
-  schedule: "0 4 * * *" # schedule in UTC time
+  schedule: "0 3 * * *" # schedule in UTC time
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 4
   jobTemplate:

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: otp-data-builder-waltti-dev
 spec:
-  schedule: "0 3 * * *" # schedule in UTC time
+  schedule: "30 2 * * *" # schedule in UTC time
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 4
   jobTemplate:

--- a/roles/aks-apply/files/dev/pelias-data-container-builder-dev-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-data-container-builder-dev-dev.yml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: pelias-data-container-builder-dev
 spec:
-  schedule: "0 5 * * *" # schedule in UTC time
+  schedule: "45 2 * * *" # schedule in UTC time
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 4
   jobTemplate:


### PR DESCRIPTION
This change is so that the data builders run before developers start their work day. Because of lack of free resources, the data builders replace some pods in the environment which can cause some services to be unavailable for a bit.