### PR TITLE
DT-3938 - development

### DIFF
--- a/roles/aks-apply/files/dev/digitransit-deployer-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-deployer-dev.yml
@@ -107,3 +107,5 @@ spec:
           limits:
             memory: 1024Mi
             cpu: 1000m
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/digitransit-performance-tests-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-performance-tests-dev.yml
@@ -78,3 +78,5 @@ spec:
           limits:
             memory: "128Mi"
             cpu: "1000M"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/digitransit-proxy-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-proxy-dev.yml
@@ -169,3 +169,5 @@ spec:
             limits:
               memory: "1152Mi"
               cpu: "3000m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/digitransit-sentry-analytics-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-sentry-analytics-dev.yml
@@ -80,3 +80,5 @@ spec:
           limits:
             memory: "256Mi"
             cpu: "100m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/digitransit-site-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-site-dev.yml
@@ -75,3 +75,5 @@ spec:
           limits:
             memory: "128Mi"
             cpu: "100m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-dev.yml
@@ -136,3 +136,5 @@ spec:
           limits:
             memory: "1536Mi"
             cpu: 2000m
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-next-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-next-dev.yml
@@ -141,3 +141,5 @@ spec:
           limits:
             memory: "1536Mi"
             cpu: 2000m
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/digitransit-ui-matka-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-matka-dev.yml
@@ -117,3 +117,5 @@ spec:
           limits:
             memory: 1024Mi
             cpu: 2000m
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/digitransit-ui-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-waltti-dev.yml
@@ -105,3 +105,5 @@ spec:
           limits:
             memory: 1200Mi
             cpu: 2000m
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/graphiql-dev.yml
+++ b/roles/aks-apply/files/dev/graphiql-dev.yml
@@ -75,3 +75,5 @@ spec:
           limits:
             memory: "64Mi"
             cpu: "500m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/hsl-map-server-dev.yml
+++ b/roles/aks-apply/files/dev/hsl-map-server-dev.yml
@@ -92,3 +92,5 @@ spec:
           limits:
             memory: 4096Mi
             cpu: 7900m
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/hsl-map-server-next-dev.yml
+++ b/roles/aks-apply/files/dev/hsl-map-server-next-dev.yml
@@ -92,3 +92,5 @@ spec:
           limits:
             memory: 4096Mi
             cpu: 7900m
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/hsl-timetable-builder-dev.yml
+++ b/roles/aks-apply/files/dev/hsl-timetable-builder-dev.yml
@@ -68,6 +68,8 @@ spec:
               limits:
                 memory: 1736Mi
                 cpu: 4000m
+          imagePullSecrets:
+            - name: hsldevcomkey
           volumes:
             - name: "docker-sock-volume"
               hostPath:

--- a/roles/aks-apply/files/dev/hsl-timetable-container-dev.yml
+++ b/roles/aks-apply/files/dev/hsl-timetable-container-dev.yml
@@ -75,3 +75,5 @@ spec:
           limits:
             memory: "48Mi"
             cpu: "100m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/navigator-server-dev.yml
+++ b/roles/aks-apply/files/dev/navigator-server-dev.yml
@@ -77,4 +77,6 @@ spec:
             cpu: 100m
           limits:
             memory: 128Mi
-            cpu: 100m        
+            cpu: 100m
+      imagePullSecrets:
+        - name: hsldevcomkey 

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-finland-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-finland-dev.yml
@@ -74,3 +74,5 @@ spec:
           limits:
             memory: "174Mi"
             cpu: "200m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-hsl-dev.yml
@@ -75,3 +75,5 @@ spec:
           limits:
             memory: "224Mi"
             cpu: "200m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-next-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-next-waltti-dev.yml
@@ -75,3 +75,5 @@ spec:
           limits:
             memory: "224Mi"
             cpu: "200m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-waltti-dev.yml
@@ -75,3 +75,5 @@ spec:
           limits:
             memory: "224Mi"
             cpu: "200m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/opentripplanner-finland-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-finland-dev.yml
@@ -71,3 +71,5 @@ spec:
           limits:
             memory: 11216Mi
             cpu: "7600m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/opentripplanner-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-hsl-dev.yml
@@ -70,3 +70,5 @@ spec:
           limits:
             memory: "9216Mi"
             cpu: "7600m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/opentripplanner-next-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-next-waltti-dev.yml
@@ -71,3 +71,5 @@ spec:
           limits:
             memory: "7168Mi"
             cpu: "7600m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/opentripplanner-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-waltti-dev.yml
@@ -71,3 +71,5 @@ spec:
           limits:
             memory: "10240Mi"
             cpu: "7600m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/otp-data-builder-finland-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-finland-dev-dev.yml
@@ -71,6 +71,8 @@ spec:
               limits:
                 memory: 12Gi
                 cpu: 6000m
+          imagePullSecrets:
+            - name: hsldevcomkey
           volumes:
             - name: "docker-sock-volume"
               hostPath:

--- a/roles/aks-apply/files/dev/otp-data-builder-finland-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-finland-prod-dev.yml
@@ -67,6 +67,8 @@ spec:
               limits:
                 memory: 12Gi
                 cpu: 6000m
+          imagePullSecrets:
+            - name: hsldevcomkey
           volumes:
             - name: "docker-sock-volume"
               hostPath:

--- a/roles/aks-apply/files/dev/otp-data-builder-hsl-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-hsl-dev-dev.yml
@@ -71,6 +71,8 @@ spec:
               limits:
                 memory: 12Gi
                 cpu: 6000m
+          imagePullSecrets:
+            - name: hsldevcomkey
           volumes:
             - name: "docker-sock-volume"
               hostPath:

--- a/roles/aks-apply/files/dev/otp-data-builder-hsl-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-hsl-prod-dev.yml
@@ -69,6 +69,8 @@ spec:
               limits:
                 memory: 12Gi
                 cpu: 6000m
+          imagePullSecrets:
+            - name: hsldevcomkey
           volumes:
             - name: "docker-sock-volume"
               hostPath:

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
@@ -71,6 +71,8 @@ spec:
               limits:
                 memory: 12Gi
                 cpu: 6000m
+          imagePullSecrets:
+            - name: hsldevcomkey
           volumes:
             - name: "docker-sock-volume"
               hostPath:

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-next-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-next-dev-dev.yml
@@ -67,6 +67,8 @@ spec:
               limits:
                 memory: 12Gi
                 cpu: 6000m
+          imagePullSecrets:
+            - name: hsldevcomkey
           volumes:
             - name: "docker-sock-volume"
               hostPath:

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-next-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-next-prod-dev.yml
@@ -67,6 +67,8 @@ spec:
               limits:
                 memory: 12Gi
                 cpu: 6000m
+          imagePullSecrets:
+            - name: hsldevcomkey
           volumes:
             - name: "docker-sock-volume"
               hostPath:

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-prod-dev.yml
@@ -67,6 +67,8 @@ spec:
               limits:
                 memory: 12Gi
                 cpu: 6000m
+          imagePullSecrets:
+            - name: hsldevcomkey
           volumes:
             - name: "docker-sock-volume"
               hostPath:

--- a/roles/aks-apply/files/dev/pelias-api-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-api-dev.yml
@@ -76,3 +76,5 @@ spec:
           limits:
             memory: "2560Mi"
             cpu: "3000m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/pelias-data-container-builder-dev-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-data-container-builder-dev-dev.yml
@@ -56,6 +56,8 @@ spec:
               limits:
                 memory: 6Gi
                 cpu: 7000m
+          imagePullSecrets:
+            - name: hsldevcomkey
           volumes:
             - name: "docker-sock-volume"
               hostPath:

--- a/roles/aks-apply/files/dev/pelias-data-container-builder-prod-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-data-container-builder-prod-dev.yml
@@ -56,6 +56,8 @@ spec:
               limits:
                 memory: 6Gi
                 cpu: 7000m
+          imagePullSecrets:
+            - name: hsldevcomkey
           volumes:
             - name: "docker-sock-volume"
               hostPath:

--- a/roles/aks-apply/files/dev/pelias-data-container-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-data-container-dev.yml
@@ -87,3 +87,5 @@ spec:
           limits:
             memory: 2584Mi
             cpu: 4000m
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/raildigitraffic2gtfsrt-dev.yml
+++ b/roles/aks-apply/files/dev/raildigitraffic2gtfsrt-dev.yml
@@ -80,3 +80,5 @@ spec:
           limits:
             memory: "1200Mi"
             cpu: "1000m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/siri2gtfsrt-dev.yml
+++ b/roles/aks-apply/files/dev/siri2gtfsrt-dev.yml
@@ -74,4 +74,6 @@ spec:
             cpu: "100m"
           limits:
             memory: "128Mi"
-            cpu: "200m"      
+            cpu: "200m"
+      imagePullSecrets:
+        - name: hsldevcomkey

--- a/roles/aks-apply/files/dev/yleisviestipalvelu-dev.yml
+++ b/roles/aks-apply/files/dev/yleisviestipalvelu-dev.yml
@@ -86,6 +86,8 @@ spec:
           limits:
             memory: "64Mi"
             cpu: "200m"
+      imagePullSecrets:
+        - name: hsldevcomkey
       volumes:
         - name: "yleisviestipalvelumessages"
           persistentVolumeClaim:

--- a/roles/aks-apply/files/template.yml
+++ b/roles/aks-apply/files/template.yml
@@ -79,6 +79,8 @@ spec:
           limits:
             memory: <mem>
             cpu: <cpus>
+      imagePullSecrets:
+        - name: hsldevcomkey      
       volumes:
         - name: <MOUNT_NAME>
-          emptyDir: {}            
+          emptyDir: {}


### PR DESCRIPTION
Deployment configurations in **dev only** changed to use imagePullSecrets for hsldevcom Docker Hub deployments. These changes have already been applied in the dev environment. All deployment, except some scheduled ones which are yet to run, are working with the updated configurations.

Production has to be updated separately.