### PR TITLE
Disable server side sentry for next ui to fix memory leak

### DIFF
--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-next-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-next-dev.yml
@@ -99,11 +99,11 @@ spec:
             secretKeyRef:
               name: sentry-dsn
               key: sentry-dsn
-        - name: SENTRY_SECRET_DSN
-          valueFrom:
-            secretKeyRef:
-              name: sentry-secret-dsn
-              key: sentry-secret-dsn
+        # - name: SENTRY_SECRET_DSN
+        #   valueFrom:
+        #     secretKeyRef:
+        #       name: sentry-secret-dsn
+        #       key: sentry-secret-dsn
         - name: GTM_ID
           valueFrom:
             secretKeyRef:

--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-next-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-next-dev.yml
@@ -109,8 +109,6 @@ spec:
             secretKeyRef:
               name: gtm-id
               key: gtm-id
-        - name: REALTIME_PATCH
-          value: "{\"HSL\": {\"mqtt\": \"wss://test92.rt.hsl.fi\"}}"
         - name: MAP_PATH_PREFIX
           value: "next-"
         - name: MAP_URL

--- a/roles/aks-apply/files/prod/digitransit-ui-hsl-next-prod.yml
+++ b/roles/aks-apply/files/prod/digitransit-ui-hsl-next-prod.yml
@@ -102,11 +102,11 @@ spec:
             secretKeyRef:
               name: sentry-dsn
               key: sentry-dsn
-        - name: SENTRY_SECRET_DSN
-          valueFrom:
-            secretKeyRef:
-              name: sentry-secret-dsn
-              key: sentry-secret-dsn
+        # - name: SENTRY_SECRET_DSN
+        #   valueFrom:
+        #     secretKeyRef:
+        #       name: sentry-secret-dsn
+        #       key: sentry-secret-dsn
         - name: GTM_ID
           valueFrom:
             secretKeyRef:

--- a/roles/aks-apply/files/prod/digitransit-ui-hsl-next-prod.yml
+++ b/roles/aks-apply/files/prod/digitransit-ui-hsl-next-prod.yml
@@ -112,8 +112,6 @@ spec:
             secretKeyRef:
               name: gtm-id
               key: gtm-id
-        - name: REALTIME_PATCH
-          value: "{\"HSL\": {\"mqtt\": \"wss://test92.rt.hsl.fi\"}}"
         - name: REDIS_HOST
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Disables server side usage of sentry to avoid memory leak. I tried to fix it in UI code with https://github.com/HSLdevcom/digitransit-ui/pull/3695 but it didn't fix it alone.

Also changed next UIs to use the normal HSL mqtt broker by removing the env that changed that behaviour.