### PR TITLE
Add type=data-builder label to data builders for kured

### DIFF
--- a/roles/aks-apply/files/dev/hsl-timetable-builder-dev.yml
+++ b/roles/aks-apply/files/dev/hsl-timetable-builder-dev.yml
@@ -11,6 +11,9 @@ spec:
     spec:
       backoffLimit: 2 # max two retries
       template:
+        metadata:
+          labels:
+            type: data-builder
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 minutes

--- a/roles/aks-apply/files/dev/otp-data-builder-finland-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-finland-dev-dev.yml
@@ -11,6 +11,9 @@ spec:
     spec:
       backoffLimit: 2 # max two retries
       template:
+        metadata:
+          labels:
+            type: data-builder
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes

--- a/roles/aks-apply/files/dev/otp-data-builder-finland-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-finland-prod-dev.yml
@@ -11,6 +11,9 @@ spec:
     spec:
       backoffLimit: 2 # max two retries
       template:
+        metadata:
+          labels:
+            type: data-builder
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes

--- a/roles/aks-apply/files/dev/otp-data-builder-hsl-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-hsl-dev-dev.yml
@@ -11,6 +11,9 @@ spec:
     spec:
       backoffLimit: 2 # max two retries
       template:
+        metadata:
+          labels:
+            type: data-builder
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 3600 # one build can take max 1 hour

--- a/roles/aks-apply/files/dev/otp-data-builder-hsl-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-hsl-prod-dev.yml
@@ -11,6 +11,9 @@ spec:
     spec:
       backoffLimit: 2 # max two retries
       template:
+        metadata:
+          labels:
+            type: data-builder
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 3600 # one build can take max 1 hour

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
@@ -11,6 +11,9 @@ spec:
     spec:
       backoffLimit: 2 # max two retries
       template:
+        metadata:
+          labels:
+            type: data-builder
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-next-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-next-dev-dev.yml
@@ -11,6 +11,9 @@ spec:
     spec:
       backoffLimit: 2 # max two retries
       template:
+        metadata:
+          labels:
+            type: data-builder
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-next-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-next-prod-dev.yml
@@ -11,6 +11,9 @@ spec:
     spec:
       backoffLimit: 2 # max two retries
       template:
+        metadata:
+          labels:
+            type: data-builder
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-prod-dev.yml
@@ -11,6 +11,9 @@ spec:
     spec:
       backoffLimit: 2 # max two retries
       template:
+        metadata:
+          labels:
+            type: data-builder
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes

--- a/roles/aks-apply/files/dev/pelias-data-container-builder-dev-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-data-container-builder-dev-dev.yml
@@ -11,6 +11,9 @@ spec:
     spec:
       backoffLimit: 2 # max two retries
       template:
+        metadata:
+          labels:
+            type: data-builder
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 mins

--- a/roles/aks-apply/files/dev/pelias-data-container-builder-prod-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-data-container-builder-prod-dev.yml
@@ -11,6 +11,9 @@ spec:
     spec:
       backoffLimit: 2 # max two retries
       template:
+        metadata:
+          labels:
+            type: data-builder
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 mins


### PR DESCRIPTION
* Add type=data-builder labels to data builders so we can prevent kured from restarting nodes while data build is on with --blocking-pod-selector=type=data-builder