### PR TITLE
Disruption budgets

### DIFF
--- a/roles/aks-apply/files/dev/digitransit-proxy-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-proxy-dev.yml
@@ -171,3 +171,15 @@ spec:
               cpu: "3000m"
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: digitransit-proxy-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: digitransit-proxy

--- a/roles/aks-apply/files/dev/digitransit-site-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-site-dev.yml
@@ -77,3 +77,15 @@ spec:
             cpu: "100m"
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: digitransit-site-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: digitransit-site

--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-dev.yml
@@ -94,3 +94,15 @@ spec:
             cpu: 2000m
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: digitransit-ui-hsl-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: digitransit-ui-hsl

--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-next-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-next-dev.yml
@@ -137,3 +137,15 @@ spec:
             cpu: 2000m
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: digitransit-ui-hsl-next-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: digitransit-ui-hsl-next

--- a/roles/aks-apply/files/dev/digitransit-ui-matka-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-matka-dev.yml
@@ -119,3 +119,15 @@ spec:
             cpu: 2000m
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: digitransit-ui-matka-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: digitransit-ui-matka

--- a/roles/aks-apply/files/dev/digitransit-ui-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-waltti-dev.yml
@@ -109,3 +109,15 @@ spec:
             cpu: 2000m
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: digitransit-ui-waltti-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: digitransit-ui-waltti

--- a/roles/aks-apply/files/dev/digitransit-ui-waltti-next-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-waltti-next-dev.yml
@@ -102,3 +102,15 @@ spec:
             cpu: 2000m
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: digitransit-ui-waltti-next-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: digitransit-ui-waltti-next

--- a/roles/aks-apply/files/dev/hsl-timetable-builder-dev.yml
+++ b/roles/aks-apply/files/dev/hsl-timetable-builder-dev.yml
@@ -13,7 +13,7 @@ spec:
       template:
         metadata:
           labels:
-            type: data-builder
+            app: hsl-timetable-builder
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 minutes
@@ -78,3 +78,15 @@ spec:
               hostPath:
                 # location on host
                 path: /var/run/docker.sock
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: hsl-timetable-builder-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: hsl-timetable-builder

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-finland-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-finland-dev.yml
@@ -76,3 +76,15 @@ spec:
             cpu: "200m"
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: opentripplanner-data-con-finland-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: opentripplanner-data-con-finland

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-hsl-dev.yml
@@ -77,3 +77,15 @@ spec:
             cpu: "200m"
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: opentripplanner-data-con-hsl-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: opentripplanner-data-con-hsl

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-next-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-next-waltti-dev.yml
@@ -77,3 +77,15 @@ spec:
             cpu: "200m"
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: opentripplanner-data-con-next-waltti-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: opentripplanner-data-con-next-waltti

--- a/roles/aks-apply/files/dev/opentripplanner-data-con-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-con-waltti-dev.yml
@@ -77,3 +77,15 @@ spec:
             cpu: "200m"
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: opentripplanner-data-con-waltti-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: opentripplanner-data-con-waltti

--- a/roles/aks-apply/files/dev/opentripplanner-finland-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-finland-dev.yml
@@ -73,3 +73,15 @@ spec:
             cpu: "7600m"
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: opentripplanner-finland-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: opentripplanner-finland

--- a/roles/aks-apply/files/dev/opentripplanner-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-hsl-dev.yml
@@ -72,3 +72,15 @@ spec:
             cpu: "7600m"
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: opentripplanner-hsl-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: opentripplanner-hsl

--- a/roles/aks-apply/files/dev/opentripplanner-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-waltti-dev.yml
@@ -73,3 +73,15 @@ spec:
             cpu: "7600m"
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: opentripplanner-waltti-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: opentripplanner-waltti

--- a/roles/aks-apply/files/dev/otp-data-builder-finland-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-finland-dev-dev.yml
@@ -13,7 +13,7 @@ spec:
       template:
         metadata:
           labels:
-            type: data-builder
+            app: otp-data-builder-finland-dev
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes
@@ -84,3 +84,15 @@ spec:
             - name: otp-data
               hostPath:
                 path: /opt/otp-data/
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: otp-data-builder-finland-dev-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: otp-data-builder-finland-dev

--- a/roles/aks-apply/files/dev/otp-data-builder-finland-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-finland-prod-dev.yml
@@ -13,7 +13,7 @@ spec:
       template:
         metadata:
           labels:
-            type: data-builder
+            app: otp-data-builder-finland-prod
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes
@@ -82,3 +82,14 @@ spec:
             - name: otp-data
               hostPath:
                 path: /opt/otp-data/
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: otp-data-builder-finland-prod-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: otp-data-builder-finland-prod

--- a/roles/aks-apply/files/dev/otp-data-builder-hsl-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-hsl-dev-dev.yml
@@ -13,7 +13,7 @@ spec:
       template:
         metadata:
           labels:
-            type: data-builder
+            app: otp-data-builder-hsl-dev
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 3600 # one build can take max 1 hour
@@ -84,3 +84,14 @@ spec:
             - name: otp-data
               hostPath:
                 path: /opt/otp-data/
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: otp-data-builder-hsl-dev-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: otp-data-builder-hsl-dev

--- a/roles/aks-apply/files/dev/otp-data-builder-hsl-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-hsl-prod-dev.yml
@@ -13,7 +13,7 @@ spec:
       template:
         metadata:
           labels:
-            type: data-builder
+            app: otp-data-builder-hsl-prod
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 3600 # one build can take max 1 hour
@@ -84,3 +84,14 @@ spec:
             - name: otp-data
               hostPath:
                 path: /opt/otp-data/
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: otp-data-builder-hsl-prod-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: otp-data-builder-hsl-prod

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
@@ -13,7 +13,7 @@ spec:
       template:
         metadata:
           labels:
-            type: data-builder
+            app: otp-data-builder-waltti-dev
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes
@@ -84,3 +84,14 @@ spec:
             - name: otp-data
               hostPath:
                 path: /opt/otp-data/
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: otp-data-builder-waltti-dev-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: otp-data-builder-waltti-dev

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-next-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-next-dev-dev.yml
@@ -13,7 +13,7 @@ spec:
       template:
         metadata:
           labels:
-            type: data-builder
+            app: otp-data-builder-waltti-next-dev
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes
@@ -80,3 +80,15 @@ spec:
             - name: otp-data
               hostPath:
                 path: /opt/otp-data/
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: otp-data-builder-waltti-next-dev-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: otp-data-builder-waltti-next-dev

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-next-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-next-prod-dev.yml
@@ -13,7 +13,7 @@ spec:
       template:
         metadata:
           labels:
-            type: data-builder
+            app: otp-data-builder-waltti-next-prod
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes
@@ -80,3 +80,15 @@ spec:
             - name: otp-data
               hostPath:
                 path: /opt/otp-data/
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: otp-data-builder-waltti-next-prod-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: otp-data-builder-waltti-next-prod

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-prod-dev.yml
@@ -13,7 +13,7 @@ spec:
       template:
         metadata:
           labels:
-            type: data-builder
+            app: otp-data-builder-waltti-prod
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes
@@ -80,3 +80,15 @@ spec:
             - name: otp-data
               hostPath:
                 path: /opt/otp-data/
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: otp-data-builder-waltti-prod-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: otp-data-builder-waltti-prod

--- a/roles/aks-apply/files/dev/pelias-data-container-builder-dev-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-data-container-builder-dev-dev.yml
@@ -13,7 +13,7 @@ spec:
       template:
         metadata:
           labels:
-            type: data-builder
+            app: pelias-data-container-builder-dev
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 mins
@@ -66,3 +66,15 @@ spec:
               hostPath:
                 # location on host
                 path: /var/run/docker.sock
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: pelias-data-container-builder-dev-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: pelias-data-container-builder-dev

--- a/roles/aks-apply/files/dev/pelias-data-container-builder-prod-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-data-container-builder-prod-dev.yml
@@ -13,7 +13,7 @@ spec:
       template:
         metadata:
           labels:
-            type: data-builder
+            app: pelias-data-container-builder-prod
         spec:
           priorityClassName: high-priority
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 mins
@@ -66,3 +66,15 @@ spec:
               hostPath:
                 # location on host
                 path: /var/run/docker.sock
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: pelias-data-container-builder-prod-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: pelias-data-container-builder-prod


### PR DESCRIPTION
* Remove type: data-builder labels used by kured, add pod disruption budgets to prevent nodes from draining while data builder pods are running
* Add pod disruption budgets also to other dev deployments that have more than 1 replica