### PR TITLE
Delay readiness test

### DIFF
--- a/roles/aks-apply/files/dev/pelias-data-container-dev.yml
+++ b/roles/aks-apply/files/dev/pelias-data-container-dev.yml
@@ -78,6 +78,7 @@ spec:
         - containerPort: 9300
           name: vip1
         readinessProbe:
+          initialDelaySeconds: 60
           periodSeconds: 5
           timeoutSeconds: 10
           failureThreshold: 2


### PR DESCRIPTION
Readiness test does not quarantee that all queries work correctly, so wait at start