### PR TITLE
OTP dev dataloading configurations 

### DIFF
--- a/roles/aks-apply/files/dev/otp-data-builder-finland-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-finland-dev-dev.yml
@@ -16,28 +16,23 @@ spec:
             app: otp-data-builder-finland-dev
         spec:
           priorityClassName: high-priority
-          activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes
+          activeDeadlineSeconds: 5400 # one build can take max 1.5 hours
           restartPolicy: OnFailure
           nodeSelector:
             pool: superpool
           containers:
           - name: otp-data-builder-finland-dev
             image: hsldevcom/otp-data-builder:latest
-            command: ["timeout"]
-            args: ["12600", "node", "index.js", "once"]
-            volumeMounts:
-              - mountPath: var/run/docker.sock
-                name: "docker-sock-volume"
-              - mountPath: opt/otp-data-builder/data
-                name: otp-data
             imagePullPolicy: Always
             securityContext:
-              allowPrivilegeEscalation: false
+              privileged: true
+              capabilities:
+                add:
+                 - NET_ADMIN
+                 - SYS_ADMIN
             env:
             - name: BUILDER_TYPE
               value: "Finland dev"
-            - name: DATA
-              value: "/opt/otp-data-builder/data"
             - name: DOCKER_AUTH
               valueFrom:
                 secretKeyRef:
@@ -54,8 +49,6 @@ spec:
               value: "{\"tampere\": {\"url\": \"http://www.tampere.fi/ekstrat/ptdata/tamperefeed_faret.zip\", \"routers\": [\"finland\"]}}"
             - name: EXTRA_UPDATERS
               value: "{\"hsl-trip-updates\": {\"topic\": \"gtfsrt/dev/fi/hsl/tu\", \"url\": \"tcp://test91.rt.hsl.fi\", \"routers\": [\"finland\"]}, \"hsl-alerts\": {\"url\": \"https://dev-api.digitransit.fi/realtime/service-alerts/v2/hsl\", \"routers\": [\"finland\"]}}"
-            - name: HOST_DATA
-              value: "/opt/otp-data"
             - name: OTP_TAG
               value: "latest"
             - name: ROUTERS
@@ -78,14 +71,6 @@ spec:
                 cpu: 6000m
           imagePullSecrets:
             - name: hsldevcomkey
-          volumes:
-            - name: "docker-sock-volume"
-              hostPath:
-                # location on host
-                path: /var/run/docker.sock
-            - name: otp-data
-              hostPath:
-                path: /opt/otp-data/
 
 ---
 

--- a/roles/aks-apply/files/dev/otp-data-builder-hsl-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-hsl-dev-dev.yml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: otp-data-builder-hsl-dev
 spec:
-  schedule: "35 4 * * *" # schedule in UTC time
+  schedule: "45 15 * * *" # schedule in UTC time
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 4
   jobTemplate:
@@ -23,21 +23,16 @@ spec:
           containers:
           - name: otp-data-builder-hsl-dev
             image: hsldevcom/otp-data-builder:latest
-            command: ["timeout"]
-            args: ["3600", "node", "index.js", "once"]
-            volumeMounts:
-              - mountPath: var/run/docker.sock
-                name: "docker-sock-volume"
-              - mountPath: opt/otp-data-builder/data
-                name: otp-data
-            imagePullPolicy: Always
             securityContext:
-              allowPrivilegeEscalation: false
+              privileged: true
+              capabilities:
+                add:
+                 - NET_ADMIN
+                 - SYS_ADMIN
+            imagePullPolicy: Always
             env:
             - name: BUILDER_TYPE
               value: "HSL dev"
-            - name: DATA
-              value: "/opt/otp-data-builder/data"
             - name: DOCKER_AUTH
               valueFrom:
                 secretKeyRef:
@@ -52,8 +47,6 @@ spec:
                   key: docker-user
             - name: EXTRA_UPDATERS
               value: "{\"hsl-trip-updates\": {\"topic\": \"gtfsrt/dev/fi/hsl/tu\", \"url\": \"tcp://test91.rt.hsl.fi\", \"routers\": [\"hsl\"]}, \"hsl-alerts\": {\"url\": \"https://dev-api.digitransit.fi/realtime/service-alerts/v2/hsl\", \"routers\": [\"hsl\"]}}"
-            - name: HOST_DATA
-              value: "/opt/otp-data"
             - name: OTP_TAG
               value: "latest"
             - name: ROUTERS
@@ -78,14 +71,6 @@ spec:
                 cpu: 6000m
           imagePullSecrets:
             - name: hsldevcomkey
-          volumes:
-            - name: "docker-sock-volume"
-              hostPath:
-                # location on host
-                path: /var/run/docker.sock
-            - name: otp-data
-              hostPath:
-                path: /opt/otp-data/
 ---
 
 apiVersion: policy/v1beta1

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
@@ -16,28 +16,23 @@ spec:
             app: otp-data-builder-waltti-dev
         spec:
           priorityClassName: high-priority
-          activeDeadlineSeconds: 12600 # one build can take max 3 hours and 30 minutes
+          activeDeadlineSeconds: 7200 # one build can take max 2 hours
           restartPolicy: OnFailure
           nodeSelector:
             pool: superpool
           containers:
           - name: otp-data-builder-waltti-dev
             image: hsldevcom/otp-data-builder:latest
-            command: ["timeout"]
-            args: ["12600", "node", "index.js", "once"]
-            volumeMounts:
-              - mountPath: var/run/docker.sock
-                name: "docker-sock-volume"
-              - mountPath: opt/otp-data-builder/data
-                name: otp-data
             imagePullPolicy: Always
             securityContext:
-              allowPrivilegeEscalation: false
+              privileged: true
+              capabilities:
+                add:
+                 - NET_ADMIN
+                 - SYS_ADMIN
             env:
             - name: BUILDER_TYPE
               value: "Waltti dev"
-            - name: DATA
-              value: "/opt/otp-data-builder/data"
             - name: DOCKER_AUTH
               valueFrom:
                 secretKeyRef:
@@ -54,8 +49,6 @@ spec:
               value: "{\"tampere\": {\"url\": \"http://www.tampere.fi/ekstrat/ptdata/tamperefeed_faret.zip\", \"routers\": [\"waltti\"]}}"
             - name: EXTRA_UPDATERS
               value: "{\"foli-alerts\": {\"url\": \"https://foli-beta.nanona.fi/gtfs-rt/reittiopas\", \"routers\": [\"waltti\"]}, \"tampere-trip-updates\": {\"url\": \"http://digitransit-proxy:8080/out/lmj.mattersoft.fi/api/gtfsrealtime/v1.0/feed/tripupdate\", \"routers\": [\"waltti\"]}, \"tampere-alerts\": {\"url\": \"http://digitransit-proxy:8080/out/lmj.mattersoft.fi/api/gtfsrealtime/v1.0/feed/servicealert\", \"routers\": [\"waltti\"]}}"
-            - name: HOST_DATA
-              value: "/opt/otp-data"
             - name: OTP_TAG
               value: "latest"
             - name: ROUTERS
@@ -78,14 +71,6 @@ spec:
                 cpu: 6000m
           imagePullSecrets:
             - name: hsldevcomkey
-          volumes:
-            - name: "docker-sock-volume"
-              hostPath:
-                # location on host
-                path: /var/run/docker.sock
-            - name: otp-data
-              hostPath:
-                path: /opt/otp-data/
 ---
 
 apiVersion: policy/v1beta1

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-linjasto2021-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-linjasto2021-dev-dev.yml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: otp-data-builder-waltti-linjasto2021-dev
 spec:
-  schedule: "30 19 * * *" # schedule in UTC time
+  schedule: "30 20 * * *" # schedule in UTC time
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 4
   jobTemplate:

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-next-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-next-dev-dev.yml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: otp-data-builder-waltti-next-dev
 spec:
-  schedule: "45 20 * * *" # schedule in UTC time
+  schedule: "50 21 * * *" # schedule in UTC time
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 4
   jobTemplate:


### PR DESCRIPTION
These are for OTP dataloaders which use latest image. 

Linjasto etc. configurations can be updated the same way after respective opentriplanner-data-container image variants have been updated.

