### PR TITLE
Revert tampere hotfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ _tmp
 /*vars/test*
 /doc/*.html
 /results
-
+.idea/*
 *~
 
 # Diffie-Hellman parameters and Mongo shared key should

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
@@ -46,7 +46,7 @@ spec:
                   name: docker-user
                   key: docker-user
             - name: EXTRA_SRC
-              value: "{\"tampere\": {\"url\": \"https://gtfsrt.blob.core.windows.net/tampere/tamperefeed_faret.zip\", \"routers\": [\"waltti\"]}}"
+              value: "{\"tampere\": {\"url\": \"http://www.tampere.fi/ekstrat/ptdata/tamperefeed_faret.zip\", \"routers\": [\"waltti\"]}}"
             - name: EXTRA_UPDATERS
               value: "{\"foli-alerts\": {\"url\": \"https://foli-beta.nanona.fi/gtfs-rt/reittiopas\", \"routers\": [\"waltti\"]}, \"tampere-trip-updates\": {\"url\": \"https://gtfsrt.blob.core.windows.net/lmj/tripupdate\", \"routers\": [\"waltti\"]}, \"tampere-alerts\": {\"url\": \"http://digitransit-proxy:8080/out/lmj.mattersoft.fi/api/gtfsrealtime/v1.0/feed/servicealert\", \"routers\": [\"waltti\"]}}"
             - name: OTP_TAG

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-next-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-next-dev-dev.yml
@@ -45,8 +45,6 @@ spec:
                 secretKeyRef:
                   name: docker-user
                   key: docker-user
-            - name: EXTRA_SRC
-              value: "{\"tampere\": {\"url\": \"https://gtfsrt.blob.core.windows.net/tampere/tamperefeed_faret.zip\", \"routers\": [\"waltti\"]}}"
             - name: OTP_TAG
               value: "otp2"
             - name: ROUTERS

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-next-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-next-prod-dev.yml
@@ -45,8 +45,6 @@ spec:
                 secretKeyRef:
                   name: docker-user
                   key: docker-user
-            - name: EXTRA_SRC
-              value: "{\"tampere\": {\"url\": \"https://gtfsrt.blob.core.windows.net/tampere/tamperefeed_deprecated.zip\", \"routers\": [\"waltti\"]}}"
             - name: OTP_TAG
               value: "otp2-prod"
             - name: ROUTERS

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-prod-dev.yml
@@ -45,8 +45,6 @@ spec:
                 secretKeyRef:
                   name: docker-user
                   key: docker-user
-            - name: EXTRA_SRC
-              value: "{\"tampere\": {\"url\": \"https://gtfsrt.blob.core.windows.net/tampere/tamperefeed_deprecated.zip\", \"routers\": [\"waltti\"]}}"
             - name: OTP_TAG
               value: "prod"
             - name: ROUTERS


### PR DESCRIPTION
revert tampere changes from tampere-url-fix-dev and tampere-url-fix as they are no longer needed. Update .gitignore to include idea files