### PR TITLE
Enable OSM blob size validation in all services

### DIFF
--- a/roles/aks-apply/files/dev/otp-data-builder-finland-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-finland-dev-dev.yml
@@ -62,8 +62,6 @@ spec:
                   key: slack-webhook
             - name: TOOLS_TAG
               value: "latest"
-            - name: DISABLE_BLOB_VALIDATION
-              value: "true"
             resources:
               requests:
                 memory: 12Gi

--- a/roles/aks-apply/files/dev/otp-data-builder-finland-dev-v3-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-finland-dev-v3-dev.yml
@@ -66,8 +66,6 @@ spec:
               value: "v3"
             - name: SLACK_CHANNEL
               value: "topic-ci-otp2"
-            - name: DISABLE_BLOB_VALIDATION
-              value: "true"
             resources:
               requests:
                 memory: 12Gi

--- a/roles/aks-apply/files/dev/otp-data-builder-finland-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-finland-prod-dev.yml
@@ -58,8 +58,6 @@ spec:
                   key: slack-webhook
             - name: TOOLS_TAG
               value: "prod"
-            - name: DISABLE_BLOB_VALIDATION
-              value: "true"
             - name: EXTRA_UPDATERS
               value: "{\"hsl-trip-updates\": {\"url\": \"tcp://pred.rt.hsl.fi\", \"routers\": [\"finland\"]}, \"linkki-alerts\": {\"remove\": true, \"routers\": [\"finland\"]}}"
             resources:

--- a/roles/aks-apply/files/dev/otp-data-builder-hsl-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-hsl-dev-dev.yml
@@ -60,8 +60,6 @@ spec:
                   key: slack-webhook
             - name: TOOLS_TAG
               value: "latest"
-            - name: DISABLE_BLOB_VALIDATION
-              value: "true"
             resources:
               requests:
                 memory: 12Gi

--- a/roles/aks-apply/files/dev/otp-data-builder-hsl-dev-v3-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-hsl-dev-v3-dev.yml
@@ -66,8 +66,6 @@ spec:
               value: "HSL"
             - name: SLACK_CHANNEL
               value: "topic-ci-otp2"
-            - name: DISABLE_BLOB_VALIDATION
-              value: "true"
             resources:
               requests:
                 memory: 12Gi

--- a/roles/aks-apply/files/dev/otp-data-builder-hsl-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-hsl-prod-dev.yml
@@ -58,8 +58,6 @@ spec:
                   key: slack-webhook
             - name: TOOLS_TAG
               value: "prod"
-            - name: DISABLE_BLOB_VALIDATION
-              value: "true"
             - name: VERSION_CHECK
               value: "HSL"
             - name: EXTRA_UPDATERS

--- a/roles/aks-apply/files/dev/otp-data-builder-varely-dev-v3-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-varely-dev-v3-dev.yml
@@ -62,8 +62,6 @@ spec:
               value: "v3"
             - name: SLACK_CHANNEL
               value: "topic-ci-otp2"
-            - name: DISABLE_BLOB_VALIDATION
-              value: "true"
             resources:
               requests:
                 memory: 12Gi

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-alt-dev-v3-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-alt-dev-v3-dev.yml
@@ -64,8 +64,6 @@ spec:
               value: "v3"
             - name: SLACK_CHANNEL
               value: "topic-ci-otp2"
-            - name: DISABLE_BLOB_VALIDATION
-              value: "true"
             resources:
               requests:
                 memory: 12Gi

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-dev.yml
@@ -64,8 +64,6 @@ spec:
                   key: slack-webhook
             - name: TOOLS_TAG
               value: "latest"
-            - name: DISABLE_BLOB_VALIDATION
-              value: "true"
             resources:
               requests:
                 memory: 12Gi

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-v3-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-dev-v3-dev.yml
@@ -66,8 +66,6 @@ spec:
               value: "v3"
             - name: SLACK_CHANNEL
               value: "topic-ci-otp2"
-            - name: DISABLE_BLOB_VALIDATION
-              value: "true"
             resources:
               requests:
                 memory: 12Gi

--- a/roles/aks-apply/files/dev/otp-data-builder-waltti-prod-dev.yml
+++ b/roles/aks-apply/files/dev/otp-data-builder-waltti-prod-dev.yml
@@ -58,8 +58,6 @@ spec:
                   key: slack-webhook
             - name: TOOLS_TAG
               value: "prod"
-            - name: DISABLE_BLOB_VALIDATION
-              value: "true"
             resources:
               requests:
                 memory: 12Gi


### PR DESCRIPTION
OpenStreetMap dump size reduction situation is now resolved and all services have got stable OSM blobs (70 MB and 521 MB for HSL and Finland, respectively). Hence, blob size drop validation should be re-enabled.