### PR TITLE
Change next-dev.digitransit.fi to run hsldevcom/digitransit-ui:otp2-dev

### DIFF
--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-v3-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-v3-dev.yml
@@ -52,7 +52,8 @@ spec:
         pool: defaultpool
       containers:
       - name: digitransit-ui-hsl-v3
-        image: hsldevcom/digitransit-ui:node-migration # testing german node migration project
+        image: hsldevcom/digitransit-ui:otp2-dev # development branch for digitransit-ui/otp2 OTP1->OTP2 migration project
+        # image: hsldevcom/digitransit-ui:node-migration # testing german node migration project
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
As `hsldevcom/digitransit-ui:node-migration` project is deferred, we can meanwhile use next-dev.digitransit.fi for OTP2 migration project's development environment.