### PR TITLE
Update HSL test service ASSET_URL

### DIFF
--- a/roles/aks-apply/files/dev/digitransit-ui-hsl-v2-test-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-ui-hsl-v2-test-dev.yml
@@ -79,7 +79,7 @@ spec:
         - name: API_URL
           value: "https://dev-api.digitransit.fi"
         - name: ASSET_URL
-          value: "https://digitransit-dev-cdn-origin.azureedge.net/ui/v2/hsl"
+          value: "https://digitransit-dev-cdn-origin.azureedge.net/ui/v2-test/hsl"
         - name: MAP_URL
           value: "https://digitransit-dev-cdn-origin.azureedge.net"
         - name: NODE_OPTS


### PR DESCRIPTION
Depends on: https://github.com/HSLdevcom/digitransit-proxy/pull/200

Related issue: DT-4193