### PR TITLE
DT-5465  part1: test configMap for OTP in dev

### DIFF
--- a/roles/aks-apply/files/dev/opentripplanner-cfgmap-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-cfgmap-dev.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opentripplanner-cfgmap
+data:
+  file-from-cfgmap: |
+    <included>
+      <logger name="org.opentripplanner.updater.stoptime.TimetableSnapshotSource" level="error"/>
+    </included>

--- a/roles/aks-apply/files/dev/opentripplanner-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-hsl-dev.yml
@@ -36,7 +36,7 @@ spec:
       labels:
         app: opentripplanner-hsl
         lastRestartDate: dummy-value
-    spec:
+    spec
       priorityClassName: medium-priority
       nodeSelector:
         pool: superpool
@@ -46,6 +46,10 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
+        volumeMounts:
+          - name: mnt
+            mountPath: /opt/opentripplanner/logback-include-extensions.xml
+            subPath: file-from-cfgmap
         readinessProbe:
           periodSeconds: 10
           timeoutSeconds: 10
@@ -72,7 +76,11 @@ spec:
           limits:
             memory: "9216Mi"
             cpu: "8000m"
-      imagePullSecrets:
+       volumes:
+       - name: mnt
+         configMap:
+           name: opentripplanner-cfgmap
+       imagePullSecrets:
         - name: hsldevcomkey
 
 ---

--- a/roles/aks-apply/files/dev/opentripplanner-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-hsl-dev.yml
@@ -36,7 +36,7 @@ spec:
       labels:
         app: opentripplanner-hsl
         lastRestartDate: dummy-value
-    spec
+    spec:
       priorityClassName: medium-priority
       nodeSelector:
         pool: superpool

--- a/roles/aks-apply/files/dev/opentripplanner-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-hsl-dev.yml
@@ -46,10 +46,6 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
-        volumeMounts:
-          - name: mnt
-            mountPath: /opt/opentripplanner/logback-include-extensions.xml
-            subPath: file-from-cfgmap
         readinessProbe:
           periodSeconds: 10
           timeoutSeconds: 10
@@ -76,11 +72,7 @@ spec:
           limits:
             memory: "9216Mi"
             cpu: "8000m"
-       volumes:
-       - name: mnt
-         configMap:
-           name: opentripplanner-cfgmap
-       imagePullSecrets:
+      imagePullSecrets:
         - name: hsldevcomkey
 
 ---

--- a/roles/aks-apply/files/dev/opentripplanner-hsl-v2-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-hsl-v2-dev.yml
@@ -47,6 +47,10 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
+        volumeMounts:
+          - name: mnt
+            mountPath: /opt/opentripplanner/logback-include-extensions.xml
+            subPath: file-from-cfgmap
         readinessProbe:
           periodSeconds: 10
           timeoutSeconds: 10
@@ -73,5 +77,9 @@ spec:
           limits:
             memory: "11Gi"
             cpu: "8000m"
+      volumes:
+      - name: mnt
+        configMap:
+          name: opentripplanner-cfgmap
       imagePullSecrets:
         - name: hsldevcomkey


### PR DESCRIPTION
This test deployment mounts logback extension into hsl otp. The log extension should remove frequently occurring message:

(TimetableSnapshotSource.java:1008) Gtfs-Rt statistics: applied xxx messages, rejected yyy messages ...

Also some warnings will go away as the extension allows only error level messages.

If the setup works, proper configuration will be mounted to production otp2 instances for reducing the logging.