### PR TITLE
Add graphiql-prod apim keys as envs

### DIFF
--- a/roles/aks-apply/files/prod/graphiql-prod.yml
+++ b/roles/aks-apply/files/prod/graphiql-prod.yml
@@ -72,6 +72,17 @@ spec:
           httpGet:
             port: 8080
             path: "/graphiql/hsl"
+        env:
+        - name: REACT_APP_API_SUBSCRIPTION_KEY_PARAM
+          valueFrom:
+            secretKeyRef:
+              name: "digitransit-subscription-key-name"
+              key: "digitransit-subscription-key-name"
+        - name: REACT_APP_API_SUBSCRIPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "prod-graphiql-apim-key"
+              key: "prod-graphiql-apim-key"
         resources:
           requests:
             memory: "384Mi"

--- a/roles/aks-apply/files/prod/keyvaultsecrets-prod.yml
+++ b/roles/aks-apply/files/prod/keyvaultsecrets-prod.yml
@@ -609,3 +609,20 @@ spec:
     secret:
       name: "otp-waltti-v2-java-opts-prod"
       dataKey: "otp-waltti-v2-java-opts-prod"
+
+---
+apiVersion: spv.no/v1alpha1
+kind: AzureKeyVaultSecret
+metadata:
+  name: "prod-graphiql-apim-key"
+  namespace: default
+spec:
+  vault:
+    name: "digitransit-dev-keyvault"
+    object:
+      name: "prod-graphiql-apim-key"
+      type: "secret"
+  output:
+    secret:
+      name: "prod-graphiql-apim-key"
+      dataKey: "prod-graphiql-apim-key"


### PR DESCRIPTION
Note: secret (prod-graphiql-apim-key) must be added to Azure KeyVault.

Related issue: [DT-5521](https://digitransit.atlassian.net/browse/DT-5521)
