### PR TITLE
DT-5521 graphiql apim key configuration for both dev and prod

### DIFF
--- a/roles/aks-apply/files/dev/graphiql-dev.yml
+++ b/roles/aks-apply/files/dev/graphiql-dev.yml
@@ -78,11 +78,16 @@ spec:
             secretKeyRef:
               name: "digitransit-subscription-key-name"
               key: "digitransit-subscription-key-name"
-        - name: REACT_APP_API_SUBSCRIPTION_KEY
+        - name: REACT_APP_DEV_API_SUBSCRIPTION_KEY
           valueFrom:
             secretKeyRef:
               name: "dev-graphiql-apim-key"
               key: "dev-graphiql-apim-key"   
+        - name: REACT_APP_API_SUBSCRIPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "graphiql-apim-key"
+              key: "graphiql-apim-key"   
         resources:
           requests:
             memory: "1Gi"

--- a/roles/aks-apply/files/dev/keyvaultsecrets-dev.yml
+++ b/roles/aks-apply/files/dev/keyvaultsecrets-dev.yml
@@ -976,7 +976,22 @@ spec:
     secret:
       name: "dev-graphiql-apim-key"
       dataKey: "dev-graphiql-apim-key"
-
+---
+apiVersion: spv.no/v1alpha1
+kind: AzureKeyVaultSecret
+metadata:
+  name: "graphiql-apim-key"
+  namespace: default
+spec:
+  vault:
+    name: "digitransit-dev-keyvault"
+    object:
+      name: "graphiql-apim-key"
+      type: "secret"
+  output:
+    secret:
+      name: "graphiql-apim-key"
+      dataKey: "graphiql-apim-key"
 ---
 apiVersion: spv.no/v1alpha1
 kind: AzureKeyVaultSecret

--- a/roles/aks-apply/files/prod/graphiql-prod.yml
+++ b/roles/aks-apply/files/prod/graphiql-prod.yml
@@ -72,6 +72,22 @@ spec:
           httpGet:
             port: 8080
             path: "/graphiql/hsl"
+        env: 
+        - name: REACT_APP_API_SUBSCRIPTION_KEY_PARAM  
+          valueFrom:
+            secretKeyRef:
+              name: "digitransit-subscription-key-name"
+              key: "digitransit-subscription-key-name"
+        - name: REACT_APP_DEV_API_SUBSCRIPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "dev-graphiql-apim-key"
+              key: "dev-graphiql-apim-key"   
+        - name: REACT_APP_API_SUBSCRIPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: "graphiql-apim-key"
+              key: "graphiql-apim-key"   
         resources:
           requests:
             memory: "384Mi"

--- a/roles/aks-apply/files/prod/keyvaultsecrets-prod.yml
+++ b/roles/aks-apply/files/prod/keyvaultsecrets-prod.yml
@@ -706,4 +706,20 @@ spec:
     secret:
       name: "prod-raildigitraffic2gtfsrt-apim-key"
       dataKey: "prod-raildigitraffic2gtfsrt-apim-key"
+---
+apiVersion: spv.no/v1alpha1
+kind: AzureKeyVaultSecret
+metadata:
+  name: "graphiql-apim-key"
+  namespace: default
+spec:
+  vault:
+    name: "digitransit-dev-keyvault"
+    object:
+      name: "graphiql-apim-key"
+      type: "secret"
+  output:
+    secret:
+      name: "graphiql-apim-key"
+      dataKey: "graphiql-apim-key"
 

--- a/roles/aks-apply/files/prod/keyvaultsecrets-prod.yml
+++ b/roles/aks-apply/files/prod/keyvaultsecrets-prod.yml
@@ -722,4 +722,19 @@ spec:
     secret:
       name: "graphiql-apim-key"
       dataKey: "graphiql-apim-key"
-
+---
+apiVersion: spv.no/v1alpha1
+kind: AzureKeyVaultSecret
+metadata:
+  name: "dev-graphiql-apim-key"
+  namespace: default
+spec:
+  vault:
+    name: "digitransit-dev-keyvault"
+    object:
+      name: "dev-graphiql-apim-key"
+      type: "secret"
+  output:
+    secret:
+      name: "dev-graphiql-apim-key"
+      dataKey: "dev-graphiql-apim-key"


### PR DESCRIPTION
- graphiql dev sub key configuration changed to point to dev env variable
- graphiql prod sub key configuration added
- prod keyvaultsecrets updated with graphiql prod sub key

Prod key exists in Azure keyvault. 
Related to a [graphiql pull request](https://github.com/HSLdevcom/graphiql-deployment/pull/57)