### PR TITLE
DT-6450 update pod disruption budgets

### DIFF
--- a/roles/aks-apply/files/dev/digitransit-proxy-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-proxy-dev.yml
@@ -243,7 +243,7 @@ kind: PodDisruptionBudget
 metadata:
   name: digitransit-proxy-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: digitransit-proxy

--- a/roles/aks-apply/files/dev/digitransit-site-dev.yml
+++ b/roles/aks-apply/files/dev/digitransit-site-dev.yml
@@ -89,7 +89,7 @@ kind: PodDisruptionBudget
 metadata:
   name: digitransit-site-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: digitransit-site

--- a/roles/aks-apply/files/dev/opentripplanner-data-server-finland-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-server-finland-dev.yml
@@ -97,7 +97,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-server-finland-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-server-finland

--- a/roles/aks-apply/files/dev/opentripplanner-data-server-finland-v3-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-server-finland-v3-dev.yml
@@ -97,7 +97,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-server-finland-v3-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-server-finland-v3

--- a/roles/aks-apply/files/dev/opentripplanner-data-server-hsl-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-server-hsl-dev.yml
@@ -97,7 +97,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-server-hsl-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-server-hsl

--- a/roles/aks-apply/files/dev/opentripplanner-data-server-hsl-v3-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-server-hsl-v3-dev.yml
@@ -97,7 +97,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-server-hsl-v3-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-server-hsl-v3

--- a/roles/aks-apply/files/dev/opentripplanner-data-server-varely-v3-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-server-varely-v3-dev.yml
@@ -97,7 +97,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-server-varely-v3-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-server-varely-v3

--- a/roles/aks-apply/files/dev/opentripplanner-data-server-waltti-alt-v3-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-server-waltti-alt-v3-dev.yml
@@ -97,7 +97,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-server-waltti-alt-v3-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-server-waltti-alt-v3

--- a/roles/aks-apply/files/dev/opentripplanner-data-server-waltti-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-server-waltti-dev.yml
@@ -97,7 +97,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-server-waltti-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-server-waltti

--- a/roles/aks-apply/files/dev/opentripplanner-data-server-waltti-v3-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-data-server-waltti-v3-dev.yml
@@ -97,7 +97,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-server-waltti-v3-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-server-waltti-v3

--- a/roles/aks-apply/files/dev/opentripplanner-hsl-v2-dev.yml
+++ b/roles/aks-apply/files/dev/opentripplanner-hsl-v2-dev.yml
@@ -22,12 +22,12 @@ metadata:
     restartAt: "03.00"
     restartLimitInterval: "720"
 spec:
-  replicas: 2
+  replicas: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 50%
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: opentripplanner-hsl-v2

--- a/roles/aks-apply/files/prod/digitransit-proxy-prod.yml
+++ b/roles/aks-apply/files/prod/digitransit-proxy-prod.yml
@@ -220,7 +220,7 @@ kind: PodDisruptionBudget
 metadata:
   name: digitransit-proxy-pdb
 spec:
-  minAvailable: 75%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: digitransit-proxy

--- a/roles/aks-apply/files/prod/digitransit-site-prod.yml
+++ b/roles/aks-apply/files/prod/digitransit-site-prod.yml
@@ -89,7 +89,7 @@ kind: PodDisruptionBudget
 metadata:
   name: digitransit-site-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: digitransit-site

--- a/roles/aks-apply/files/prod/digitransit-ui-hsl-v3-prod.yml
+++ b/roles/aks-apply/files/prod/digitransit-ui-hsl-v3-prod.yml
@@ -185,7 +185,7 @@ kind: PodDisruptionBudget
 metadata:
   name: digitransit-ui-hsl-v3-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: digitransit-ui-hsl-v3

--- a/roles/aks-apply/files/prod/digitransit-ui-matka-v3-prod.yml
+++ b/roles/aks-apply/files/prod/digitransit-ui-matka-v3-prod.yml
@@ -129,7 +129,7 @@ kind: PodDisruptionBudget
 metadata:
   name: digitransit-ui-matka-v3-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: digitransit-ui-matka-v3

--- a/roles/aks-apply/files/prod/digitransit-ui-waltti-v3-prod.yml
+++ b/roles/aks-apply/files/prod/digitransit-ui-waltti-v3-prod.yml
@@ -135,7 +135,7 @@ kind: PodDisruptionBudget
 metadata:
   name: digitransit-ui-waltti-v3-pdb
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: digitransit-ui-waltti-v3

--- a/roles/aks-apply/files/prod/hsl-map-server-prod.yml
+++ b/roles/aks-apply/files/prod/hsl-map-server-prod.yml
@@ -120,7 +120,7 @@ kind: PodDisruptionBudget
 metadata:
   name: hsl-map-server-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: hsl-map-server

--- a/roles/aks-apply/files/prod/hsl-timetable-container-prod.yml
+++ b/roles/aks-apply/files/prod/hsl-timetable-container-prod.yml
@@ -89,7 +89,7 @@ kind: PodDisruptionBudget
 metadata:
   name: hsl-timetable-container-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: hsl-timetable-container

--- a/roles/aks-apply/files/prod/opentripplanner-data-con-finland-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-data-con-finland-prod.yml
@@ -88,7 +88,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-con-finland-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-con-finland

--- a/roles/aks-apply/files/prod/opentripplanner-data-con-finland-v3-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-data-con-finland-v3-prod.yml
@@ -89,7 +89,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-con-finland-v3-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-con-finland-v3

--- a/roles/aks-apply/files/prod/opentripplanner-data-con-hsl-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-data-con-hsl-prod.yml
@@ -89,7 +89,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-con-hsl-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-con-hsl

--- a/roles/aks-apply/files/prod/opentripplanner-data-con-hsl-v3-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-data-con-hsl-v3-prod.yml
@@ -89,7 +89,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-con-hsl-v3-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-con-hsl-v3

--- a/roles/aks-apply/files/prod/opentripplanner-data-con-kela-v3-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-data-con-kela-v3-prod.yml
@@ -89,7 +89,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-con-kela-v3-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-con-kela-v3

--- a/roles/aks-apply/files/prod/opentripplanner-data-con-varely-v3-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-data-con-varely-v3-prod.yml
@@ -89,7 +89,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-con-varely-v3-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-con-varely-v3

--- a/roles/aks-apply/files/prod/opentripplanner-data-con-waltti-alt-v3-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-data-con-waltti-alt-v3-prod.yml
@@ -89,7 +89,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-con-waltti-alt-v3-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-con-waltti-alt-v3

--- a/roles/aks-apply/files/prod/opentripplanner-data-con-waltti-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-data-con-waltti-prod.yml
@@ -89,7 +89,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-con-waltti-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-con-waltti

--- a/roles/aks-apply/files/prod/opentripplanner-data-con-waltti-v3-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-data-con-waltti-v3-prod.yml
@@ -89,7 +89,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-data-con-waltti-v3-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-data-con-waltti-v3

--- a/roles/aks-apply/files/prod/opentripplanner-finland-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-finland-prod.yml
@@ -78,7 +78,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-finland-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-finland

--- a/roles/aks-apply/files/prod/opentripplanner-finland-v2-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-finland-v2-prod.yml
@@ -100,7 +100,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-finland-v2-pdb
 spec:
-  minAvailable: 50% # TODO increase
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-finland-v2

--- a/roles/aks-apply/files/prod/opentripplanner-hsl-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-hsl-prod.yml
@@ -91,7 +91,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-hsl-pdb
 spec:
-  minAvailable: 75%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-hsl

--- a/roles/aks-apply/files/prod/opentripplanner-hsl-v2-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-hsl-v2-prod.yml
@@ -100,7 +100,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-hsl-v2-pdb
 spec:
-  minAvailable: 80%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-hsl-v2

--- a/roles/aks-apply/files/prod/opentripplanner-kela-v2-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-kela-v2-prod.yml
@@ -113,7 +113,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-kela-v2-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-kela-v2

--- a/roles/aks-apply/files/prod/opentripplanner-varely-v2-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-varely-v2-prod.yml
@@ -103,3 +103,15 @@ spec:
           name: opentripplanner-cfgmap
       imagePullSecrets:
         - name: hsldevcomkey
+
+---
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: opentripplanner-varely-v2-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: opentripplanner-varely-v2

--- a/roles/aks-apply/files/prod/opentripplanner-waltti-alt-v2-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-waltti-alt-v2-prod.yml
@@ -113,7 +113,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-waltti-alt-v2-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-waltti-alt-v2

--- a/roles/aks-apply/files/prod/opentripplanner-waltti-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-waltti-prod.yml
@@ -92,7 +92,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-waltti-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-waltti

--- a/roles/aks-apply/files/prod/opentripplanner-waltti-v2-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-waltti-v2-prod.yml
@@ -100,7 +100,7 @@ kind: PodDisruptionBudget
 metadata:
   name: opentripplanner-waltti-v2-pdb
 spec:
-  minAvailable: 75%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: opentripplanner-waltti-v2

--- a/roles/aks-apply/files/prod/pelias-api-prod.yml
+++ b/roles/aks-apply/files/prod/pelias-api-prod.yml
@@ -108,7 +108,7 @@ kind: PodDisruptionBudget
 metadata:
   name: pelias-api-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: pelias-api

--- a/roles/aks-apply/files/prod/pelias-data-container-prod.yml
+++ b/roles/aks-apply/files/prod/pelias-data-container-prod.yml
@@ -122,7 +122,7 @@ kind: PodDisruptionBudget
 metadata:
   name: pelias-data-container-pdb
 spec:
-  minAvailable: 75%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: pelias-data-container

--- a/roles/aks-apply/files/prod/siri2gtfsrt-prod.yml
+++ b/roles/aks-apply/files/prod/siri2gtfsrt-prod.yml
@@ -89,7 +89,7 @@ kind: PodDisruptionBudget
 metadata:
   name: siri2gtfsrt-pdb
 spec:
-  minAvailable: 50%
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: siri2gtfsrt


### PR DESCRIPTION
* The current limits can cause problems with new node pools that have max surge > 1