### PR TITLE
HSL-1096-Set-up-horizontal-kubernetes-autoscaling-for-opentripplanner-hsl-v2

### DIFF
--- a/roles/aks-apply/files/prod/opentripplanner-hsl-v2-hpa-prod.yml
+++ b/roles/aks-apply/files/prod/opentripplanner-hsl-v2-hpa-prod.yml
@@ -1,0 +1,32 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: opentripplanner-hsl-v2-hpa
+  namespace: default 
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: opentripplanner-hsl-v2
+  minReplicas: 2
+  maxReplicas: 40
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 300 # 5 min
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 300
+    scaleDown:
+      stabilizationWindowSeconds: 300 # 5 min
+      policies:
+      - type: Pods
+        value: 1
+        periodSeconds: 300


### PR DESCRIPTION
The purpose of this PR is to add HPA for opentripplanner-hsl-v2 deployment.