### PR TITLE
Add backup builderpool for prod data builds

### DIFF
--- a/roles/aks-apply/files/prod/otp-data-builder-kela-v3-prod.yml
+++ b/roles/aks-apply/files/prod/otp-data-builder-kela-v3-prod.yml
@@ -18,8 +18,24 @@ spec:
         spec:
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 minutes
           restartPolicy: OnFailure
-          nodeSelector:
-            agentpool: builderpool
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
+                    - builderpool2
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                preference:
+                  matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
           tolerations:
           - key: "builder"
             operator: "Equal"

--- a/roles/aks-apply/files/prod/otp-data-builder-varely-v3-prod.yml
+++ b/roles/aks-apply/files/prod/otp-data-builder-varely-v3-prod.yml
@@ -18,8 +18,24 @@ spec:
         spec:
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 minutes
           restartPolicy: OnFailure
-          nodeSelector:
-            agentpool: builderpool
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
+                    - builderpool2
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                preference:
+                  matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
           tolerations:
           - key: "builder"
             operator: "Equal"

--- a/roles/aks-apply/files/prod/otp-street-builder-finland-v3-prod.yml
+++ b/roles/aks-apply/files/prod/otp-street-builder-finland-v3-prod.yml
@@ -18,8 +18,24 @@ spec:
         spec:
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 minutes
           restartPolicy: OnFailure
-          nodeSelector:
-            agentpool: builderpool
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
+                    - builderpool2
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                preference:
+                  matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
           tolerations:
           - key: "builder"
             operator: "Equal"

--- a/roles/aks-apply/files/prod/otp-street-builder-hsl-v3-prod.yml
+++ b/roles/aks-apply/files/prod/otp-street-builder-hsl-v3-prod.yml
@@ -18,8 +18,24 @@ spec:
         spec:
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 minutes
           restartPolicy: OnFailure
-          nodeSelector:
-            agentpool: builderpool
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
+                    - builderpool2
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                preference:
+                  matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
           tolerations:
           - key: "builder"
             operator: "Equal"

--- a/roles/aks-apply/files/prod/otp-street-builder-waltti-v3-prod.yml
+++ b/roles/aks-apply/files/prod/otp-street-builder-waltti-v3-prod.yml
@@ -18,8 +18,24 @@ spec:
         spec:
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 minutes
           restartPolicy: OnFailure
-          nodeSelector:
-            agentpool: builderpool
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
+                    - builderpool2
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                preference:
+                  matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
           tolerations:
           - key: "builder"
             operator: "Equal"

--- a/roles/aks-apply/files/prod/otp-transit-builder-finland-v3-prod.yml
+++ b/roles/aks-apply/files/prod/otp-transit-builder-finland-v3-prod.yml
@@ -18,8 +18,24 @@ spec:
         spec:
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 minutes
           restartPolicy: OnFailure
-          nodeSelector:
-            agentpool: builderpool
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
+                    - builderpool2
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                preference:
+                  matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
           tolerations:
           - key: "builder"
             operator: "Equal"

--- a/roles/aks-apply/files/prod/otp-transit-builder-hsl-v3-prod.yml
+++ b/roles/aks-apply/files/prod/otp-transit-builder-hsl-v3-prod.yml
@@ -18,8 +18,24 @@ spec:
         spec:
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 minutes
           restartPolicy: OnFailure
-          nodeSelector:
-            agentpool: builderpool
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
+                    - builderpool2
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                preference:
+                  matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
           tolerations:
           - key: "builder"
             operator: "Equal"

--- a/roles/aks-apply/files/prod/otp-transit-builder-waltti-v3-prod.yml
+++ b/roles/aks-apply/files/prod/otp-transit-builder-waltti-v3-prod.yml
@@ -18,8 +18,24 @@ spec:
         spec:
           activeDeadlineSeconds: 9000 # one build can take max 2 hours and 30 minutes
           restartPolicy: OnFailure
-          nodeSelector:
-            agentpool: builderpool
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
+                    - builderpool2
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                preference:
+                  matchExpressions:
+                  - key: agentpool
+                    operator: In
+                    values:
+                    - builderpool
           tolerations:
           - key: "builder"
             operator: "Equal"


### PR DESCRIPTION
- This should be merged only after the dev equivalents have been deemed sufficiently tested
- Ref https://github.com/HSLdevcom/digitransit-kubernetes-deploy/pull/258