### PR TITLE
AB#669 - Add priority expander setup for dev cluster autoscaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ az aks update \
     --load-balancer-managed-outbound-ip-count <number of ips> \
     --load-balancer-outbound-ports <number of ports>
 ```
+
+#### Node pool priority 
+
+- The autoscaler is set up to use the `priority` expander and a max node provisioning time of 10 minutes (as opposed to the `random` expander and 15 minutes).
+- `roles/aks-setup/tasks/main.yml` sets `--cluster-autoscaler-profile expander=priority,max-node-provision-time=10m` when creating a cluster, so any freshly (re)created cluster already has this enabled.
+- The actual priority order is defined by the `cluster-autoscaler-priority-expander` ConfigMap in `kube-system`. The regexes in it are matched against each node pool's underlying VM Scale Set name (e.g. `aks-builderpool-<hash>-vmss`), not the plain pool name, and higher priority numbers win.
+
 ### Pod autoscaling
 
 - We use horizontal pod autoscaling for most production services. Each service has a related hpa yaml where autoscaling settings are configured.

--- a/roles/aks-apply/files/dev/cluster-autoscaler-priority-expander-dev.yml
+++ b/roles/aks-apply/files/dev/cluster-autoscaler-priority-expander-dev.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-autoscaler-priority-expander
+  namespace: kube-system
+data:
+  priorities: |-
+    20:
+      - .*-builderpool-.*
+    10:
+      - .*-builderpool2-.*
+    1:
+      - .*

--- a/roles/aks-setup/tasks/main.yml
+++ b/roles/aks-setup/tasks/main.yml
@@ -33,7 +33,8 @@
     --node-osdisk-type Ephemeral \
     --mode System \
     --node-taints CriticalAddonsOnly=true:NoSchedule \
-    --nodepool-name {{system_nodepool_name}}
+    --nodepool-name {{system_nodepool_name}} \
+    --cluster-autoscaler-profile expander=priority,max-node-provision-time=10m
   delegate_to: localhost
   ignore_errors: "{{ ansible_check_mode }}"
   with_items:


### PR DESCRIPTION
- Previous related work https://github.com/HSLdevcom/digitransit-kubernetes-deploy/pull/258
- This PR handles the autoscaler prioritizing correct pools, while the previous PR handles scheduling a pod on the correct node if there is a choice of nodes.